### PR TITLE
Added ActivityPub demo client interface

### DIFF
--- a/src/config.js.example
+++ b/src/config.js.example
@@ -1,6 +1,6 @@
 var globals = { 
-        dav_link: "https://localhost:8443/DAV/home/demo/Public/record-test.ttl",
-        describe: "https://localhost:8443/describe/?url=",
-        sparql_endpoint: "https://localhost:8443/sparql",
-        host: "https://localhost:8443" 
+        dav_link: "https://id.myopenlink.net/public_home/KingsleyUyiIdehen/RWW-QA/test1.ttl",
+        describe: "https://linkeddata.uriburner.com/describe/?url=",
+        sparql_endpoint: "https://linkeddata.uriburner.com/sparql",
+        host: "https://linkeddata.uriburner.com"
 };

--- a/src/config.js.example
+++ b/src/config.js.example
@@ -1,0 +1,6 @@
+var globals = { 
+        dav_link: "https://localhost:8443/DAV/home/demo/Public/record-test.ttl",
+        describe: "https://localhost:8443/describe/?url=",
+        sparql_endpoint: "https://localhost:8443/sparql",
+        host: "https://localhost:8443" 
+};

--- a/src/data-entry-form.html
+++ b/src/data-entry-form.html
@@ -393,7 +393,24 @@
     </fieldset>
   </form>
   <span class="tip"></span>
-</div>
+  </div>
+
+  <div class="modal fade" tabindex="-1" role="dialog" id="configError">
+      <div class="modal-dialog" role="document">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  <h4 class="modal-title">Configuration Error</h4>
+              </div>
+              <div class="modal-body">
+                  <p>Condiguration (config.js) missing</p>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">Dismiss</button>
+              </div>
+          </div>
+      </div>
+  </div>
 <!-- jQuery modal login dialog: End -->
 
 </body>

--- a/src/data-entry-form.html
+++ b/src/data-entry-form.html
@@ -123,10 +123,10 @@
                     data-original-title="Out box URI"></span>
                   <input type="text" class="form-control" placeholder="http://domain/DAV/outbox/" id="outboxID">
                   <p class="errorMessage" id="outboxErrorID"></p>
-                  <span>
+                  <!--span>
                    <button id="resolveBtnID" type="button"
                       class="btn btn-warning">Fetch</button>
-                  </span>
+                  </span-->
                 </div>
                 <div class="form-group">
                   <label for="apObjectID">Activity Object</label>
@@ -152,7 +152,8 @@
               <h1 style="text-align:center">Status</h1>
               <table id="apTableID" class="table table-bordered"
                 style="table-layout: fixed; max-width:600px;">
-                <div style="padding-top: 25px" id="sendResultID">Here will be status URI...</div>
+                  <div style="padding-top: 25px"><label for="sendResultID">Activity Id</label><span id="sendResultID">N/A</span></div>
+                  <div style="padding-top: 25px"><label for="apPostID">Object Id</label><span id="apPostID">N/A</span></div>
               </table>
             </div>
           </div>

--- a/src/data-entry-form.html
+++ b/src/data-entry-form.html
@@ -35,7 +35,8 @@
   <div class="container">
     <!-- Create tabs menu -->
     <ul class="nav nav-tabs">
-      <li class="active" id="dbmsTabID"><a data-toggle="tab" href="#dbmsID">DBMS</a></li>
+      <li class="active" id="apTabID"><a data-toggle="tab" href="#apID">JSON-LD</a></li>
+      <li id="dbmsTabID"><a data-toggle="tab" href="#dbmsID">DBMS</a></li>
       <li id="fsTabID"><a data-toggle="tab" href="#fsID">File System</a></li>
       <li id="aboutTabID"><a data-toggle="tab" href="#aboutID">About</a></li>
       <!-- Start Dropdown -->
@@ -66,7 +67,7 @@
           <div >
             <label style="font-weight: normal" >SPARQL Endpoint</label> 
             <!-- CMSB: TO DO: Default sparql endpoint. Move to a const in data-entry-form.js -->
-            <input type="text" style="width: 20em" value="https://linkeddata.uriburner.com/sparql" id="sparql_endpoint">
+            <input type="text" style="width: 20em" value="https://localhost:8443/sparql" id="sparql_endpoint">
           </div>
 
           <!-- Console Print Commands Checkbox  -->
@@ -108,8 +109,58 @@
 
     <!-- Add content to the tabs-->
     <div class="tab-content">
+      <!-- Start JSONLD Tab -->
+      <div id="apID" class="tab-pane fade in active">
+        <div class="container">
+          <div class="row">
+            <!-- Form Div (Left Side) -->
+            <div class="col-xs-6">
+              <h1 style="text-align:center">Data Entry</h1>
+              <form id="apFormID" class="form" method="post">
+                <div class="form-group">
+                  <label for="outboxID">Out Box</label>
+                  <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip"
+                    data-original-title="Out box URI"></span>
+                  <input type="text" class="form-control" placeholder="http://domain/DAV/outbox/" id="outboxID">
+                  <p class="errorMessage" id="outboxErrorID"></p>
+                  <span>
+                   <button id="resolveBtnID" type="button"
+                      class="btn btn-warning">Fetch</button>
+                  </span>
+                </div>
+                <div class="form-group">
+                  <label for="apObjectID">Activity Object</label>
+                  <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip"
+                    data-original-title="Help!!!"></span>
+                  <textarea class="form-control" placeholder="JSON-LD" rows="10"
+                    style="resize:vertical" id="apObjectID" >
+                  </textarea>
+                  <p class="errorMessage" id="apObjectErrorID"></p>
+                </div>
+                <!-- Start Buttons -->
+                <div class=button-wrapper>
+                  <span>
+                    <button id="sendBtnID" type="button"
+                      class="btn btn-success">Send</button>
+                  </span>
+                </div>
+                <!-- End Buttons -->
+              </form>
+            </div>
+              <!-- End of Form Div -->
+            <div class="col-xs-6">
+              <h1 style="text-align:center">Status</h1>
+              <table id="apTableID" class="table table-bordered"
+                style="table-layout: fixed; max-width:600px;">
+                <div style="padding-top: 25px" id="sendResultID">Here will be status URI...</div>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- End JOSNLD Tab -->
       <!-- Start DBMS Tab -->
-      <div id="dbmsID" class="tab-pane fade in active">
+      <div id="dbmsID" class="tab-pane fade">
         <div class="container">
           <div class="row">
             <!-- Form Div (Left Side) -->
@@ -228,7 +279,7 @@
                 <div class="form-group">
                   <label for="docNameID2">Document Name</label>
                   <input type="text" class="form-control"
-                    value="https://id.myopenlink.net/public_home/KingsleyUyiIdehen/RWW-QA/test1.ttl"
+                    value="https://localhost:8443/DAV/home/dba/Public/record-test.ttl"
                     id="docNameID2" >
                   <p class="errorMessage" id="docNameErrorID2"></p>
                 </div>
@@ -289,7 +340,7 @@
           <p style="padding-top: 10px"> Generic SPARQL Data Entry Form 1.0.4<br>
             Description: Simple Data Entry Form that helps unravel the power of RDF and SPARQL with regards
             to Structured Data creation and interaction. <br>
-            Creator: <a href="https://jordan.solid.openlinksw.com:8444/profile/card#me">Jordan Idehen</a>
+            Creator: <a href="https://jordan.solid.openlinksw.com:8443/profile/card#me">Jordan Idehen</a>
             (<a href="https://github.com/jidehen#this">Github</a>, <a
               href="https://www.linkedin.com/in/jordan-idehen-143934157/#this">LinkedIn</a>) <br>
             Supervisor: <a href="https://github.com/OpenLinkSoftware#this">OpenLink Software</a> <br>
@@ -335,7 +386,7 @@
   <span>or enter your WebID or the URL of your identity provider:</span><br/>
   <form>
     <fieldset>
-      <input type="text" id="login_custom_idp" value="" placeholder="https://my-identity.provider" 
+      <input type="text" id="login_custom_idp" value="https://localhost:8443" placeholder="https://my-identity.provider" 
        class="text ui-widget-content ui-corner-all">
     </fieldset>
   </form>

--- a/src/data-entry-form.html
+++ b/src/data-entry-form.html
@@ -19,6 +19,7 @@
   <script src="./solid-client-authn.bundle.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/rdflib@0.20.1/dist/rdflib.min.js"></script>
 
+  <script src="config.js"></script>
   <script src="data-entry-form.js"></script>
   <script src="login-jquery-modal/login-jquery-modal.js"></script>
 </head>

--- a/src/data-entry-form.html
+++ b/src/data-entry-form.html
@@ -403,7 +403,7 @@
                   <h4 class="modal-title">Configuration Error</h4>
               </div>
               <div class="modal-body">
-                  <p>Condiguration (config.js) missing</p>
+                  <p>Configuration (config.js) missing, please use a copy of config.js.example with relevant default values</p>
               </div>
               <div class="modal-footer">
                   <button type="button" class="btn btn-default" data-dismiss="modal">Dismiss</button>

--- a/src/data-entry-form.html
+++ b/src/data-entry-form.html
@@ -36,7 +36,7 @@
   <div class="container">
     <!-- Create tabs menu -->
     <ul class="nav nav-tabs">
-      <li class="active" id="apTabID"><a data-toggle="tab" href="#apID">JSON-LD</a></li>
+      <li class="active" id="apTabID"><a data-toggle="tab" href="#apID">ActivityPub</a></li>
       <li id="dbmsTabID"><a data-toggle="tab" href="#dbmsID">DBMS</a></li>
       <li id="fsTabID"><a data-toggle="tab" href="#fsID">File System</a></li>
       <li id="aboutTabID"><a data-toggle="tab" href="#aboutID">About</a></li>
@@ -132,7 +132,7 @@
                 <div class="form-group">
                   <label for="apObjectID">Activity Object</label>
                   <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip"
-                    data-original-title="Help!!!"></span>
+                    data-original-title="JSON-LD document representing ActivityPub object"></span>
                   <textarea class="form-control" placeholder="JSON-LD" rows="10"
                     style="resize:vertical" id="apObjectID" >
                   </textarea>

--- a/src/data-entry-form.js
+++ b/src/data-entry-form.js
@@ -892,7 +892,7 @@ async function setTableSize() {
     } else {
       var msg = await resp.text();
       hideSpinner();
-      console.error("Error: " + msg)
+      console.error("Error: " + resp.status)
       await showSnackbar('Table Size Failed', `SPARQL endpoint Error: ${resp.status} ${resp.statusText}`);
     }
 
@@ -930,9 +930,7 @@ async function resolveOutBox() {
     resp = await solidClient.fetch(url, options);
     if (resp.ok) {
       var body = await resp.text();
-      // ck for json
       var profile = JSON.parse (body);
-      // ck for outbox
       DOC.iSel("outboxID").value = profile.outbox;
       console.log(resp.status + " - " + resp.statusText);
       hideSpinner();
@@ -943,7 +941,7 @@ async function resolveOutBox() {
   } catch (e) {
     hideSpinner();
     console.error('Fetch Failed', e);
-    showSnackbar('Fetch Failed', '' + e);
+    showSnackbar('Outbox Fetch Failed', '' + e);
   }
 }
 
@@ -1546,7 +1544,7 @@ async function updateTable() {
   const options = {
     method: 'GET',
     headers: {
-      'Content-type': 'application/sparql-results+json; charset=UTF-8',
+      'Accept': 'application/sparql-results+json; charset=UTF-8',
     },
     credentials: 'include',
     mode: 'cors',

--- a/src/data-entry-form.js
+++ b/src/data-entry-form.js
@@ -609,6 +609,15 @@ function nonvalidatedObject() {
 // These functions handle the data table
 //
 
+function makeLink(link) {
+  var href = link;
+  if (DOC.iSel("fctID").checked == true) { //if fct checkbox is checked
+      href = globals.describe + link;
+  }    
+  link = '<a target="_blank" href="' + href + '">' + link + '</a>';
+  return link;
+}
+
 // This function allows hyperlinks to be used in the table
 function tableFormat(str) {
   // Regular Expression for URIs in table specifically
@@ -1012,7 +1021,7 @@ async function sendActivity() {
     if (resp.ok) {
       console.log(resp.status + " - " + resp.statusText);
       activity_url = resp.headers.get('location');
-      DOC.iSel("sendResultID").innerHTML = activity_url;
+      DOC.iSel("sendResultID").innerHTML = makeLink(activity_url);
       hideSpinner();
     } else {
       throw new Error(`Error ${resp.status} - ${resp.statusText}`);
@@ -1054,7 +1063,7 @@ async function showActivtyDetails (activity_url) {
       var body = await resp.text();
       var activity = JSON.parse (body);
       if (activity.object)
-        DOC.iSel("apPostID").innerHTML = activity.object.id;
+        DOC.iSel("apPostID").innerHTML = makeLink(activity.object.id);
       else
         DOC.iSel("apPostID").innerHTML = 'N/A';
     } else {
@@ -1992,6 +2001,8 @@ $(document).ready(function () {
     }
   });
 
+  if (typeof (globals) == 'undefined')
+    $('#configError').modal('show');
   // check for permalink
   gAppState.loadPermalink();
 

--- a/src/data-entry-form.js
+++ b/src/data-entry-form.js
@@ -118,16 +118,19 @@ class AppState {
     }
     else {
       var documentName;
-      document.getElementById('apObjectID').innerHTML = 
+      DOC.iSel('apObjectID').innerHTML = 
             '{\n' +
             '  "@context": "https://www.w3.org/ns/activitystreams",\n' +
             '  "type": "Note",\n' +
             '  "summary":null,\n' +
             '  "content": ""\n' +
             '}';
+      document.getElementById('login_custom_idp').value = globals.host;  
+      document.getElementById('docNameID2').value = globals.dav_link;  
+      document.getElementById('sparql_endpoint').value = globals.sparql_endpoint;  
       if (this.getCurTab() === "fs") {
         $('a[href="#fsID"]').tab('show');
-        if (this.lastState.documentName)
+      if (this.lastState.documentName)
           document.getElementById('docNameID2').value = this.lastState.documentName;
       } else if (this.getCurTab() === "dbms") {
         $('a[href="#dbmsID"]').tab('show');
@@ -235,7 +238,7 @@ class AppState {
       DOC.iSel("docNameID2").value = solid_storage_value;
     } else {
       DOC.iSel("docNameID").value = "urn:records:test";
-      DOC.iSel("docNameID2").value = "https://localhost:8443/DAV/home/dba/Public/record-test.ttl";
+      DOC.iSel("docNameID2").value = globals.dav_link;
     }
 
     // value from permalink
@@ -613,8 +616,8 @@ function tableFormat(str) {
   var graph = gAppState.checkValue("docNameID", "docNameID2");
   var strLabel = str; // variable for what is show on screen in the href
 
-  if (str.includes("https://localhost:8443/describe/?url=")) {// of str is in fct format
-    strLabel = strLabel.replace("https://localhost:8443/describe/?url=", "");
+  if (str.includes(globals.describe)) {// of str is in fct format
+    strLabel = strLabel.replace(globals.describe, "");
     strLabel = strLabel.replace("%23", "#");
   }
 
@@ -1429,17 +1432,17 @@ async function queryGen() {
           var object = data.results.bindings[i].object.value;
           if (DOC.iSel("fctID").checked == true) { //if fct checkbox is checked
             if (subject.includes(graph) || regexp.test(subject)) { //if subject is not a literal value
-              subject = "https://localhost:8443/describe/?url=" + data.results.bindings[i].subject.value;
+              subject = globals.describe + data.results.bindings[i].subject.value;
               subject = subject.replace("#", "%23"); // replaces # with %23 for fct results
             }
 
             if (predicate.includes(graph) || regexp.test(predicate)) { //if subject is not a literal value
-              predicate = "https://localhost:8443/describe/?url=" + data.results.bindings[i].predicate.value;
+              predicate = globals.describe + data.results.bindings[i].predicate.value;
               predicate = predicate.replace("#", "%23");
             }
 
             if (object.includes(graph) || regexp.test(object)) {
-              object = "https://localhost:8443/describe/?url=" + data.results.bindings[i].object.value;
+              object = globals.describe + data.results.bindings[i].object.value;
               object = object.replace("#", "%23");
             } else { //if object is literal value
               object = data.results.bindings[i].object.value;
@@ -1568,17 +1571,17 @@ async function updateTable() {
           var object = data.results.bindings[i].object.value;
           if (DOC.iSel("fctID").checked == true) { //if fct checkbox is checked
             if (subject.includes(graph) || regexp.test(subject)) { //if subject is not a literal value
-              subject = "https://localhost:8443/describe/?url=" + data.results.bindings[i].subject.value;
+              subject = globals.describe + data.results.bindings[i].subject.value;
               subject = subject.replace("#", "%23"); // replaces # with %23 for fct results
             }
 
             if (predicate.includes(graph) || regexp.test(predicate)) { //if subject is not a literal value
-              predicate = "https://localhost:8443/describe/?url=" + data.results.bindings[i].predicate.value;
+              predicate = globals.describe + data.results.bindings[i].predicate.value;
               predicate = predicate.replace("#", "%23");
             }
 
             if (object.includes(graph) || regexp.test(object)) {
-              object = "https://localhost:8443/describe/?url=" + data.results.bindings[i].object.value;
+              object = globals.describe + data.results.bindings[i].object.value;
               object = object.replace("#", "%23");
             } else { //if object is literal value
               object = data.results.bindings[i].object.value;


### PR DESCRIPTION
The changes include:
- ActivityPub entry form allowing logged-in user to post JSON-LD/activity streams profile documents to their outboxes.
- configuration file to replace constants in JS code.
- Fix for Accept vs Content-Type in GET request, also preferences for Turtle in profile Accept due to lack of compact form JSON-LD support in rdflib.  